### PR TITLE
Updated to use stable snapshots and removed lynx requirement

### DIFF
--- a/functions/download.func
+++ b/functions/download.func
@@ -18,7 +18,16 @@ function download
 			fi
 		fi
 
-		url_sourcemod_package=`lynx -dump "$sourcemod_mirror" | egrep -o "$search_pattern" | tail -1`
+		sourcemod_latest_basename=`wget -qO- "$sourcemod_mirror/sourcemod-latest-linux"`
+		
+		if [[ ${#sourcemod_latest_basename} -gt "0" ]]; then
+			url_sourcemod_package="$sourcemod_mirror$sourcemod_latest_basename"
+		elif hash lynx 2>/dev/null; then
+			echo "Attempting to scrape the download mirror for the package using lynx..."
+			url_sourcemod_package=`lynx -dump "$sourcemod_mirror" | egrep -o "$search_pattern" | tail -1`
+		else
+			echo -e "${red}Error: Could not retrieve latest version of Sourcemod.  Please install lynx for scraping.$reset"
+		fi
 
 		if [[ $url_sourcemod_package == "" ]]; then
 			echo -e "${red}Error: Scanning for the latest sourcemod package failed.$reset"

--- a/functions/download.func
+++ b/functions/download.func
@@ -13,8 +13,8 @@ function download
 				sourcemod_mirror="$SNAPSHOT_DEV_MIRROR"
 				search_pattern="$SNAPSHOT_DEV_SEARCHPATTER"
 			else
-				sourcemod_mirror="$STABLE_MIRROR"
-				search_pattern="$STABLE_SEARCHPATTER"
+				sourcemod_mirror="$SNAPSHOT_STABLE_MIRROR"
+				search_pattern="$SNAPSHOT_STABLE_SEARCHPATTER"
 			fi
 		fi
 

--- a/settings
+++ b/settings
@@ -1,10 +1,7 @@
 # The source code of this page will be searched for the latest sourcemod package
 # We assume that the last one is the latest
-STABLE_MIRROR="http://www.gsptalk.com/mirror/sourcemod/"
-STABLE_SEARCHPATTER="http:.*sourcemod.*linux.*"
-
 SNAPSHOT_STABLE_MIRROR="http://www.sourcemod.net/smdrop/1.7/"
-SNAPSHOT_STABLE_SEARCHPATTER="http:.*sourcemod-.*-linux.*"
+SNAPSHOT_STABLE_SEARCHPATTER="http:.*sourcemod-.*-linux.*gz"
 
 SNAPSHOT_DEV_MIRROR="http://www.sourcemod.net/smdrop/1.8/"
-SNAPSHOT_DEV_SEARCHPATTER="http:.*sourcemod-.*-linux.*"
+SNAPSHOT_DEV_SEARCHPATTER="http:.*sourcemod-.*-linux.*gz"


### PR DESCRIPTION
[SourceMod is now on a rolling release cycle](https://forums.alliedmods.net/showthread.php?t=271402), so the stable snapshots should be considered the default and the non-snapshot mirror removed.  (1.7.2, the latest version in the current stable non-snapshot mirror, is six months old.)

The SourceMod team also added a plain text file named "sourcemod-latest-linux" in each of the SourceMod directory listings containing the latest file name ([1.7](http://www.sourcemod.net/smdrop/1.7/sourcemod-latest-linux), [1.8](http://www.sourcemod.net/smdrop/1.8/sourcemod-latest-linux)); the script will attempt to retrieve and use that first, falling back to text scraping with `lynx` only if necessary.  An error message will show if `lynx` is not available when attempting the scrape.

With the addition of that file, it broke the existing `*_PATTERN` variables, so the pattern has also been updated to only match links ending in `gz`.
